### PR TITLE
feat(validation): export Zod as validation package

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": false,
   "version": "0.2.0-1",
   "type": "module",
+  "types": "dist/index.d.ts",
   "sideEffects": false,
   "repository": {
     "type": "git",
@@ -89,6 +90,11 @@
       "import": "./dist/server/quick/index.js",
       "require": "./dist/server/quick/index.cjs"
     },
+    "./server/validation": {
+      "types": "./dist/server/validation/index.d.ts",
+      "import": "./dist/server/validation/index.js",
+      "require": "./dist/server/validation/index.cjs"
+    },
     "./client": {
       "types": "./dist/client/index.d.ts",
       "import": "./dist/client/index.js",
@@ -109,6 +115,11 @@
       "import": "./dist/dev/index.js",
       "require": "./dist/dev/index.cjs"
     },
+    "./validation": {
+      "types": "./dist/validation/index.d.ts",
+      "import": "./dist/validation/index.js",
+      "require": "./dist/validation/index.cjs"
+    },
     "./wasm": {
       "types": "./dist/wasm/index.d.ts",
       "import": "./dist/wasm/index.js",
@@ -125,6 +136,7 @@
   "peerDependencies": {
     "@biomejs/biome": "2.2.2",
     "@hono/node-server": "^1.19.1",
+    "@hono/zod-validator": "^0.7.2",
     "@rollup/plugin-commonjs": "^28.0.6",
     "@rollup/plugin-node-resolve": "^16.0.1",
     "@rollup/plugin-typescript": "^12.1.4",
@@ -139,8 +151,8 @@
     "fs-extra": "^11.3.1",
     "hono": "^4.9.2",
     "ky": "^1.8.2",
-    "nodemon": "^3.1.10",
     "mitata": "^1.0.34",
+    "nodemon": "^3.1.10",
     "ora": "^8.2.0",
     "tsdown": "^0.14.1",
     "type-fest": "^4.41.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@hono/node-server':
         specifier: ^1.19.1
         version: 1.19.1(hono@4.9.5)
+      '@hono/zod-validator':
+        specifier: ^0.7.2
+        version: 0.7.2(hono@4.9.5)(zod@4.1.5)
       '@rollup/plugin-commonjs':
         specifier: ^28.0.6
         version: 28.0.6
@@ -185,6 +188,12 @@ packages:
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
+
+  '@hono/zod-validator@0.7.2':
+    resolution: {integrity: sha512-ub5eL/NeZ4eLZawu78JpW/J+dugDAYhwqUIdp9KYScI6PZECij4Hx4UsrthlEUutqDDhPwRI0MscUfNkvn/mqQ==}
+    peerDependencies:
+      hono: '>=3.9.0'
+      zod: ^3.25.0 || ^4.0.0
 
   '@inquirer/checkbox@4.2.2':
     resolution: {integrity: sha512-E+KExNurKcUJJdxmjglTl141EwxWyAHplvsYJQgSwXf8qiNWkTxTuCCqmhFEmbIXd4zLaGMfQFJ6WrZ7fSeV3g==}
@@ -2078,6 +2087,11 @@ snapshots:
   '@hono/node-server@1.19.1(hono@4.9.5)':
     dependencies:
       hono: 4.9.5
+
+  '@hono/zod-validator@0.7.2(hono@4.9.5)(zod@4.1.5)':
+    dependencies:
+      hono: 4.9.5
+      zod: 4.1.5
 
   '@inquirer/checkbox@4.2.2(@types/node@24.3.0)':
     dependencies:

--- a/src/server/validation/index.ts
+++ b/src/server/validation/index.ts
@@ -1,0 +1,5 @@
+import * as mod from "@hono/zod-validator";
+
+export * from "@hono/zod-validator";
+export { mod as zod };
+export default mod;

--- a/src/validation/index.ts
+++ b/src/validation/index.ts
@@ -1,0 +1,5 @@
+import * as mod from "zod";
+
+export * from "zod";
+export { mod as zod };
+export default mod;

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
     "server/quick/index": "src/server/quick/index.ts",
     "client/index": "src/client/index.ts",
     "cli/index": "src/cli/index.ts",
+    "validation/index": "src/validation/index.ts",
     "wasm/index": "src/wasm/index.ts",
   },
   copy: [

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
     "server/jsx/index": "src/server/jsx/index.ts",
     "server/tiny/index": "src/server/tiny/index.ts",
     "server/quick/index": "src/server/quick/index.ts",
+    "server/validation/index": "src/server/validation/index.ts",
     "client/index": "src/client/index.ts",
     "cli/index": "src/cli/index.ts",
     "validation/index": "src/validation/index.ts",


### PR DESCRIPTION
This pull request adds support for validation utilities to both the server and client sides of the project. It introduces new entry points for validation, integrates the `@hono/zod-validator` and `zod` libraries, and updates configuration and dependency files to ensure proper type definitions and module resolutions.

**Validation support integration:**

* Added new entry points `src/server/validation/index.ts` and `src/validation/index.ts` to export and re-export validation utilities from `@hono/zod-validator` and `zod`, respectively. [[1]](diffhunk://#diff-f26d82445e7e701507efd43603e3e51a29aa5e4f5b5c199817055924368c609aR1-R5) [[2]](diffhunk://#diff-73429bc4a5944eb32fb5dde601970daf1df52fe19e2f60f6034559469aa4e5e0R1-R5)
* Updated `tsdown.config.ts` to include the new validation entry points for both server and client builds.

**Dependency and configuration updates:**

* Added `@hono/zod-validator` as a peer dependency and updated `pnpm-lock.yaml` to include its resolution and snapshot, ensuring compatibility with `hono` and `zod`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R139) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR17-R19) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR192-R197) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR2091-R2095)
* Updated `package.json` to add type definitions and module exports for the new validation entry points. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R7) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R93-R97) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R118-R122)
* Minor reordering of the `nodemon` dependency in `package.json` for consistency.